### PR TITLE
Add uuid and ascii validation translation

### DIFF
--- a/stubs/lang/ja/validation.php
+++ b/stubs/lang/ja/validation.php
@@ -13,6 +13,7 @@ return [
     'alpha_dash' => ':attributeはアルファベットとダッシュ(-)及び下線(_)がご利用できます。',
     'alpha_num' => ':attributeはアルファベット数字がご利用できます。',
     'array' => ':attributeは配列でなくてはなりません。',
+    'ascii' => ':attributeは半角の英数字や記号のみで指定してください。',
     'before' => ':attributeには、:dateより前の日付をご利用ください。',
     'before_or_equal' => ':attributeには、:date以前の日付をご利用ください。',
     'between' => [
@@ -117,6 +118,7 @@ return [
     'uploaded' => ':attributeのアップロードに失敗しました。',
     'uppercase' => ':attributeは、大文字のみで指定してください。',
     'url' => ':attributeに正しい形式を指定してください。',
+    'ulid' => ':attributeに有効なULIDを指定してください。',
     'uuid' => ':attributeに有効なUUIDを指定してください。',
 
     /*


### PR DESCRIPTION
uuid と ascii のバリデーションが加わりました。
https://github.com/laravel/framework/pull/45218/files
でマージされています。

実際のリリースはまだなので、一応、下書きに設定しておきます。
ascii の日本語訳は迷う所がありますが、一応プルリクのようにしておきました。
（適宜編集して下さい🙂）

下記の正規表現でチェックされており、
https://github.com/voku/portable-ascii/blob/master/src/voku/helper/ASCII.php#L184
タブや改行や記号はOKですが、日本語文字はもちろんダメで、`u` ではなく、`ü` ももちろんダメという感じです。

肝心の本家の方の en/validation.php にプルリク出ていないので、まずはそちらの方が先だったりしますが😅