### PR TITLE
Fix GitHub permission

### DIFF
--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -5,6 +5,9 @@ on:
      paths:
        - '**.php'
 
+permissions:
+   contents: write
+   
 jobs:
   php-code-styling:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [released]
 
+permissions:
+   contents: write
+   
 jobs:
   update:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fix for GitHub default permission change: https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/