### PR TITLE
Add 'contains' validation error message in Japanese translation

### DIFF
--- a/stubs/lang/ja/validation.php
+++ b/stubs/lang/ja/validation.php
@@ -25,6 +25,7 @@ return [
     'boolean' => ':attributeは、trueかfalseを指定してください。',
     'can' => ':attributeに権限のない値が含まれています。',
     'confirmed' => ':attributeと確認フィールドが一致していません。',
+    'contains' => ':attributeに必須の値がありません。',
     'current_password' => 'パスワードが正しくありません。',
     'date' => ':attributeには有効な日付を指定してください。',
     'date_equals' => ':attributeには、:dateと同じ日付けを指定してください。',


### PR DESCRIPTION
contains エラーメッセージを追加しました☕

元はこちらです。
https://github.com/laravel/framework/pull/51348/files
https://github.com/laravel/framework/commit/2f8b95ae59712f52778a1cb35addaa9fbf6d891b
