### PR TITLE
`prohibits` バリデーションメッセージの :attributeプレースホルダ修正

### DIFF
--- a/stubs/lang/ja/validation.php
+++ b/stubs/lang/ja/validation.php
@@ -128,7 +128,7 @@ return [
     'prohibited_if_accepted' => ':attributeは、:otherが承認された場合は、入力禁止です。',
     'prohibited_if_declined' => ':attributeは、:otherが拒否された場合は、入力禁止です。',
     'prohibited_unless' => ':otherが:valueでない場合、:attributeは入力禁止です。',
-    'prohibits' => 'attributeは:otherの入力を禁じています。',
+    'prohibits' => ':attributeは:otherの入力を禁じています。',
     'regex' => ':attributeに正しい形式を指定してください。',
     'required' => ':attributeは必ず指定してください。',
     'required_array_keys' => ':attributeは、:valuesの項目を含めてください。',


### PR DESCRIPTION
`prohibits`のバリデーションメッセージで、:attribute プレースホルダのコロンが抜けていたため追加しました